### PR TITLE
Adding support for SLC6/CentOS7 for BDII ansible

### DIFF
--- a/tasks/install_UMD_repo.yml
+++ b/tasks/install_UMD_repo.yml
@@ -5,9 +5,15 @@
 - name: Install yum-priorities plugin
   yum: name=yum-priorities state=present
 
-# Install UMD4 repo
-- name: Install UMD4 repo
+# Install UMD4 repo SL6
+- name: Install UMD4 SLC6 repo
+  yum: name=http://repository.egi.eu/sw/production/umd/4/sl6/x86_64/updates/umd-release-4.1.3-1.el6.noarch.rpm state=present
+  when: (ansible_distribution == "Scientific" and ansible_distribution_major_version == "6")
+
+# Install UMD4 repo CentOS7
+- name: Install UMD4 CentOS7 repo
   yum: name=http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/base/umd-release-4.0.0-1.el7.noarch.rpm state=present
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
 
 # Import UMD4 gpg key
 - name: Import UMD4 gpg key

--- a/templates/etc/bdii/gip/site-urls.conf.j2
+++ b/templates/etc/bdii/gip/site-urls.conf.j2
@@ -2,8 +2,12 @@
 # using the ansible-bdii-site role
 
 SITEBDII ldap://{{ ansible_fqdn }}:2170/mds-vo-name=resource,o=grid
-{%if SITEURLS is defined %}
+{% if SITEURLS is defined %}
 {% for alias, url in SITEURLS.iteritems() %}
+{% if ':' in url %}
+{{ alias }} ldap://{{ url }}/mds-vo-name=resource,o=grid
+{% else %}
 {{ alias }} ldap://{{ url }}:2170/mds-vo-name=resource,o=grid
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
These are some minor changes to get the bdii service running using ansible on an SLC6/CentOS7 machine.

We may end up deploying the production version of this on centos7 but for now I'm trying out ansible and thought these changes may help anyone not wanting to go to centos7 yet.

In Edinburgh we also have different ports for different SITEURLS so we needed to expand the configuration a little here.